### PR TITLE
Fix: linking to armadillo

### DIFF
--- a/include/armadillo_config.h
+++ b/include/armadillo_config.h
@@ -1,0 +1,10 @@
+#ifndef CONFIG_H
+#define CONFIG_H
+
+#ifdef USE_RCPPARMADILLO
+#include <RcppArmadillo.h>
+#else // USE_RCPPARMADILLO
+#include <armadillo>
+#endif // USE_RCPPARMADILLO
+
+#endif // CONFIG_H

--- a/include/hlmgwr.h
+++ b/include/hlmgwr.h
@@ -99,7 +99,7 @@ public:
         nvg = G.n_cols;
         nvx = X.n_cols;
         nvz = Z.n_cols;
-        bw_optim = bw;
+        bw_optim = true;
     }
 
     explicit HGWR(const arma::mat& G, const arma::mat& X, const arma::mat& Z, const arma::vec& y, const arma::mat& u, const arma::uvec& group, const Options& options)
@@ -112,19 +112,21 @@ public:
         this->max_retries = options.max_retries;
         this->verbose = options.verbose;
         this->ml_type = options.ml_type;
+        bw_optim = true;
     }
 
     explicit HGWR(const arma::mat& G, const arma::mat& X, const arma::mat& Z, const arma::vec& y, const arma::mat& u, const arma::uvec& group, KernelType kernel)
         : HGWR(G, X, Z, y, u, group)
     {
         this->kernel = kernel;
+        bw_optim = true;
     }
 
     explicit HGWR(const arma::mat& G, const arma::mat& X, const arma::mat& Z, const arma::vec& y, const arma::mat& u, const arma::uvec& group, KernelType kernel, double bw)
         : HGWR(G, X, Z, y, u, group, kernel)
     {
         this->bw = bw;
-        bw_optim = bw;
+        bw_optim = false;
     }
 
     explicit HGWR(const arma::mat& G, const arma::mat& X, const arma::mat& Z, const arma::vec& y, const arma::mat& u, const arma::uvec& group, KernelType kernel, double bw, const Options& options)
@@ -132,7 +134,7 @@ public:
     {
         this->kernel = kernel;
         this->bw = bw;
-        bw_optim = bw;
+        bw_optim = false;
     }
 
     explicit HGWR(const arma::mat& G, const arma::mat& X, const arma::mat& Z, const arma::vec& y, const arma::mat& u, const arma::uvec& group, KernelType kernel, double bw, const Options& options, const PrintFunction printer)
@@ -239,6 +241,7 @@ private:
     arma::mat u;
     arma::uvec group;
     double bw = 0.0;
+    bool bw_optim = false;
     KernelType kernel = KernelType::GAUSSIAN;
     GWRKernelFunctionSquared gwr_kernel = &gwr_kernel_gaussian2;
 
@@ -273,7 +276,6 @@ private:
     arma::uword nvz;
 
     /* diagnostic information */
-    double bw_optim = 0;
     double loglik = 0;
     arma::vec trS;
     arma::vec var_beta;

--- a/include/hlmgwr.h
+++ b/include/hlmgwr.h
@@ -14,7 +14,7 @@ struct ML_Params
     arma::vec* Yf;
     arma::mat* Zf;
     arma::vec* beta;
-    size_t ngroup;
+    arma::uword ngroup;
     arma::uword n;
     arma::uword p;
     arma::uword q;
@@ -266,8 +266,8 @@ private:
     std::unique_ptr<arma::vec[]> Yf;
     std::unique_ptr<arma::vec[]> Ygf;
     std::unique_ptr<arma::vec[]> Yhf;
-    size_t ngroup;
-    size_t ndata;
+    arma::uword ngroup;
+    arma::uword ndata;
     arma::uword nvg;
     arma::uword nvx;
     arma::uword nvz;

--- a/include/hlmgwr.h
+++ b/include/hlmgwr.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <memory>
+#include <functional>
 #include "armadillo_config.h"
 
 namespace hgwr
@@ -83,7 +84,7 @@ public:  // Type defs
         double bw;
     };
 
-    using BwSelectionArgs = std::pair<const arma::mat&, const arma::vec&>;
+    using BwSelectionArgs = std::pair<std::reference_wrapper<arma::mat>, std::reference_wrapper<arma::vec>>;
 
 public:
     explicit HGWR(const arma::mat& G, const arma::mat& X, const arma::mat& Z, const arma::vec& y, const arma::mat& u, const arma::uvec& group)
@@ -235,8 +236,8 @@ public:
     void set_printer(PrintFunction printer) { pcout = printer; }
 
 public:
-    double criterion_bw(double bw, BwSelectionArgs args);
-    double golden_selection(const double lower, const double upper, const bool adaptive, BwSelectionArgs args);
+    double criterion_bw(double bw, const BwSelectionArgs& args);
+    double golden_selection(const double lower, const double upper, const bool adaptive, const BwSelectionArgs& args);
     void fit_gwr();
     arma::vec fit_gls();
     double fit_D(ML_Params* params);

--- a/include/hlmgwr.h
+++ b/include/hlmgwr.h
@@ -122,6 +122,13 @@ public:
         bw_optim = true;
     }
 
+    explicit HGWR(const arma::mat& G, const arma::mat& X, const arma::mat& Z, const arma::vec& y, const arma::mat& u, const arma::uvec& group, KernelType kernel, const Options& options)
+        : HGWR(G, X, Z, y, u, group, options)
+    {
+        this->kernel = kernel;
+        bw_optim = true;
+    }
+
     explicit HGWR(const arma::mat& G, const arma::mat& X, const arma::mat& Z, const arma::vec& y, const arma::mat& u, const arma::uvec& group, KernelType kernel, double bw)
         : HGWR(G, X, Z, y, u, group, kernel)
     {

--- a/include/hlmgwr.h
+++ b/include/hlmgwr.h
@@ -171,7 +171,14 @@ public:
     void set_group(const arma::uvec& value) { group = value; }
     
     double get_bw() { return bw; }
-    void set_bw(double value) { bw = value; }
+    void set_bw(double value)
+    {
+        bw = value;
+        bw_optim = false;
+    }
+
+    bool get_bw_optim() { return bw_optim; }
+    void set_bw_optim(bool value) { bw_optim = value; }
     
     KernelType get_kernel() { return kernel; }
     void set_kernel(KernelType value)

--- a/include/hlmgwr.h
+++ b/include/hlmgwr.h
@@ -3,7 +3,7 @@
 
 #include <string>
 #include <memory>
-#include <armadillo>
+#include "armadillo_config.h"
 
 namespace hgwr
 {

--- a/src/hlmgwr.cpp
+++ b/src/hlmgwr.cpp
@@ -12,7 +12,7 @@ using namespace hgwr;
 
 const double log2pi = log(2.0 * M_PI);
 
-double HGWR::criterion_bw(double bw, BwSelectionArgs args)
+double HGWR::criterion_bw(double bw, const BwSelectionArgs& args)
 {
     mat Vig = args.first, Viy = args.second;
     const size_t ngroup = Viy.n_rows;
@@ -48,7 +48,7 @@ double HGWR::criterion_bw(double bw, BwSelectionArgs args)
     return cv;
 }
 
-double HGWR::golden_selection(const double lower, const double upper, const bool adaptive, BwSelectionArgs args)
+double HGWR::golden_selection(const double lower, const double upper, const bool adaptive, const BwSelectionArgs& args)
 {
     double xU = upper, xL = lower;
     bool adaptBw = adaptive;
@@ -125,7 +125,7 @@ void HGWR::fit_gwr()
     /// Check whether need to optimize bw
     if (bw_optim)
     {
-        BwSelectionArgs args = make_pair<const mat&, const vec&>(Vig, Viy);
+        BwSelectionArgs args = make_pair<std::reference_wrapper<arma::mat>, std::reference_wrapper<arma::vec>>(Vig, Viy);
         double upper = ngroup, lower = k + 1;
         bw = golden_selection(lower, upper, true, args);
     }

--- a/src/hlmgwr.cpp
+++ b/src/hlmgwr.cpp
@@ -56,8 +56,8 @@ double HGWR::golden_selection(const double lower, const double upper, const bool
     const double R = (sqrt(5)-1)/2;
     int iter = 0;
     double d = R * (xU - xL);
-    double x1 = adaptBw ? floor(xL + d) : (xL + d);
-    double x2 = adaptBw ? round(xU - d) : (xU - d);
+    double x1 = min(adaptBw ? round(xL + d) : (xL + d), xU);
+    double x2 = max(adaptBw ? floor(xU - d) : (xU - d), xL);
     double f1 = criterion_bw(x1, args);
     double f2 = criterion_bw(x2, args);
     double d1 = f2 - f1;
@@ -70,7 +70,7 @@ double HGWR::golden_selection(const double lower, const double upper, const bool
         {
             xL = x2;
             x2 = x1;
-            x1 = adaptBw ? round(xL + d) : (xL + d);
+            x1 = min(adaptBw ? round(xL + d) : (xL + d), xU);
             f2 = f1;
             f1 = criterion_bw(x1, args);
         }
@@ -78,7 +78,7 @@ double HGWR::golden_selection(const double lower, const double upper, const bool
         {
             xU = x1;
             x1 = x2;
-            x2 = adaptBw ? floor(xU - d) : (xU - d);
+            x2 = max(adaptBw ? floor(xU - d) : (xU - d), xL);
             f1 = f2;
             f2 = criterion_bw(x2, args);
         }

--- a/src/hlmgwr.cpp
+++ b/src/hlmgwr.cpp
@@ -1,13 +1,8 @@
-#ifdef HGWRR_RCPP
-// [[Rcpp::depends(RcppArmadillo)]]
-#endif
-
 #include "hlmgwr.h"
 #include <sstream>
 #include <iomanip>
 #include <string>
 #include <utility>
-#include <armadillo>
 #include <gsl/gsl_multimin.h>
 #include <gsl/gsl_errno.h>
 


### PR DESCRIPTION
CHAGELOG

- Add a macro definition `USE_RCPPARMADILLO` to identify whether or not to use `<RcppArmadillo.h>`.
- Use `bw_optim` as a flag of whether bw needs to be optimised. This is caused by value mismatch of 0.0 between R and C++.
- Other type errors.